### PR TITLE
Add the ability to ignore case when matching paths.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+ * Added the ability to generate case-insensitive regular expressions
+
 ## 0.2.1
 
 * Removed unnecessary code.

--- a/lib/src/regexp.dart
+++ b/lib/src/regexp.dart
@@ -5,21 +5,32 @@ import 'token.dart';
 ///
 /// See [parse] for details about the optional [parameters] parameter.
 ///
-/// See [tokensToRegExp] for details about the optional [prefix] parameter and
-/// return value.
+/// See [tokensToRegExp] for details about the optional [prefix] and
+/// [caseSensitive] parameters and the return value.
 RegExp pathToRegExp(
   String path, {
   List<String> parameters,
   bool prefix = false,
+  bool caseSensitive = true,
 }) =>
-    tokensToRegExp(parse(path, parameters: parameters), prefix: prefix);
+    tokensToRegExp(
+      parse(path, parameters: parameters),
+      prefix: prefix,
+      caseSensitive: caseSensitive,
+    );
 
 /// Creates a [RegExp] from [tokens].
 ///
 /// If [prefix] is true, the returned regular expression matches the beginning
 /// of input until a delimiter or end of input. Otherwise it matches the entire
 /// input.
-RegExp tokensToRegExp(List<Token> tokens, {bool prefix = false}) {
+///
+/// The resulting [RegExp] will respect the [caseSensitive] parameter.
+RegExp tokensToRegExp(
+  List<Token> tokens, {
+  bool prefix = false,
+  bool caseSensitive = true,
+}) {
   final buffer = StringBuffer('^');
   String lastPattern;
   for (final token in tokens) {
@@ -35,5 +46,5 @@ RegExp tokensToRegExp(List<Token> tokens, {bool prefix = false}) {
     // in which case, anything may follow.
     buffer.write(r'(?=/|$)');
   }
-  return RegExp(buffer.toString());
+  return RegExp(buffer.toString(), caseSensitive: caseSensitive);
 }

--- a/test/path_to_regexp_test.dart
+++ b/test/path_to_regexp_test.dart
@@ -370,12 +370,34 @@ void main() {
         throws(given: {'type': 'random'}),
       ],
     );
+    // Case insensitive path matching.
+    tests(r'/insensitive-token/:foo', caseSensitive: false, tokens: [
+      path('/insensitive-token/'),
+      parameter('foo')
+    ], regExp: [
+      matches(
+        '/insensitive-token/1',
+        ['/insensitive-token/1', '1'],
+        extracts: {'foo': '1'},
+      ),
+      matches(
+        '/INSENSITIVE-TOKEN/1',
+        ['/INSENSITIVE-TOKEN/1', '1'],
+        extracts: {'foo': '1'},
+      )
+    ], toPath: [
+      returns(
+        '/insensitive-token/1',
+        given: {'foo': '1'},
+      ),
+    ]);
   });
 }
 
 void tests(
   String path, {
   bool prefix = false,
+  bool caseSensitive = true,
   List<Matcher> tokens = const [],
   List<RegExpCase> regExp = const [],
   List<ToPathCase> toPath = const [],
@@ -387,7 +409,11 @@ void tests(
       expect(parsedTokens, tokens);
     });
 
-    final parsedRegExp = tokensToRegExp(parsedTokens, prefix: prefix);
+    final parsedRegExp = tokensToRegExp(
+      parsedTokens,
+      prefix: prefix,
+      caseSensitive: caseSensitive,
+    );
     for (final matchCase in regExp) {
       final path = matchCase.path;
       final match = parsedRegExp.matchAsPrefix(path);


### PR DESCRIPTION
A new `caseSensitive` parameter is added to both regexp methods, which
is directly passed to the RegExp constructor. No changes are made to
path generation, which will continue to use whichever casing is present
in the original path specification.