### PR TITLE
Add support for path parameters with dashes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .packages
 doc/
 pubspec.lock
+.idea

--- a/lib/src/parse.dart
+++ b/lib/src/parse.dart
@@ -10,7 +10,7 @@ const _defaultPattern = '([^/]+?)';
 ///   1. The parameter name.
 ///   2. An optional pattern.
 final _parameterRegExp = RegExp(
-    /* (1) */ r':(\w+)'
+    /* (1) */ r':([\w-]+)'
     /* (2) */ r'(\((?:\\.|[^\\()])+\))?');
 
 /// Parses a [path] specification.

--- a/test/path_to_regexp_test.dart
+++ b/test/path_to_regexp_test.dart
@@ -73,6 +73,35 @@ void main() {
         returns('/foo', given: {'key': 'foo'}),
       ],
     );
+    tests(
+      '/:dashed-key',
+      tokens: [
+        path('/'),
+        parameter('dashed-key'),
+      ],
+      regExp: [
+        matches('/foo', ['/foo', 'foo'], extracts: {'dashed-key': 'foo'}),
+        matches(
+          '/foo.json',
+          ['/foo.json', 'foo.json'],
+          extracts: {'dashed-key': 'foo.json'},
+        ),
+        matches(
+          '/foo%2Fbar',
+          ['/foo%2Fbar', 'foo%2Fbar'],
+          extracts: {'dashed-key': 'foo%2Fbar'},
+        ),
+        matches(
+          r'/;,:@&=+$-_.!~*()',
+          [r'/;,:@&=+$-_.!~*()', r';,:@&=+$-_.!~*()'],
+          extracts: {'dashed-key': r';,:@&=+$-_.!~*()'},
+        ),
+        mismatches('/foo/bar'),
+      ],
+      toPath: [
+        returns('/foo', given: {'dashed-key': 'foo'}),
+      ],
+    );
   });
 
   group('prefix path', () {


### PR DESCRIPTION
Currently, paths that contain `-` in the parameters are not supported, and the values are not matched or extracted correctly. This PRs adds support for parameters containing `-`.